### PR TITLE
Fixed isActivePeriod logic, used in pause/resume due to mover and temperature

### DIFF
--- a/source/usr/local/emhttp/plugins/parity.check.tuning/parity.check.tuning.php
+++ b/source/usr/local/emhttp/plugins/parity.check.tuning/parity.check.tuning.php
@@ -487,7 +487,7 @@ switch (strtolower($command)) {
 						// Decide if we are outside an increment window
 						// so must not resume even though drives cooled
 						if (! isActivePeriod()) {
-							parityTuningLoggerDebug(_('Outside increment scheguled time'));
+							parityTuningLoggerDebug(_('Outside increment scheduled time'));
 							if ((($parityTuningCfg['parityTuningScheduled'] && file_exists(PARITY_TUNING_SCHEDULED_FILE)))
 							|| (($parityTuningCfg['parityTuningManual'] && file_exists(PARITY_TUNING_MANUAL_FILE)))
 							|| (($parityTuningCfg['parityTuningAutomatic'] && file_exists(PARITY_TUNING_AUTOMATIC_FILE)))){
@@ -1706,9 +1706,9 @@ function isActivePeriod() {
 		$pauseTime  = ($parityTuningCfg['parityTuningPauseHour'] * 60) + $parityTuningCfg['parityTuningPauseMinute'];
 		$currentTime = (date("H") * 60) + date("i");
 		parityTuningLoggerTesting(".. pauseTime=$pauseTime, resumeTime=$resumeTime, currentTime=$currentTime");
-		if ($pauseTime > $resumeTime) {         // We need to allow for times spanning midnight!
+		if ($pauseTime > $resumeTime) {
 			$inPeriod = (($currentTime > $resumeTime) && ($currentTime < $pauseTime)) ? 1 : 0;
-		} else {
+		} else { // We need to allow for times spanning midnight!
 			$inPeriod = (($currentTime > $resumeTime) || ($currentTime < $pauseTime)) ? 1 : 0;
 		}
 	}

--- a/source/usr/local/emhttp/plugins/parity.check.tuning/parity.check.tuning.php
+++ b/source/usr/local/emhttp/plugins/parity.check.tuning/parity.check.tuning.php
@@ -1707,9 +1707,9 @@ function isActivePeriod() {
 		$currentTime = (date("H") * 60) + date("i");
 		parityTuningLoggerTesting(".. PauseTIme=$pauseTime, Resumetime=$resumeTime, currentTime=$currentTime");
 		if ($pauseTime > $resumeTime) {         // We need to allow for times spanning midnight!
-			$inPeriod = (($currentTime < $resumeTime) && ($currentTime > $pauseTime)) ? 1 : 0;
+			$inPeriod = (($currentTime > $resumeTime) && ($currentTime < $pauseTime)) ? 1 : 0;
 		} else {
-			$inPeriod =(($currentTime > $resumeTime) && ($currentTime < $pauseTime)) ? 1 : 0;
+			$inPeriod = (($currentTime > $resumeTime) || ($currentTime < $pauseTime)) ? 1 : 0;
 		}
 	}
 	parityTuningLoggerTesting('isAcivePeriod()='.$inPeriod);

--- a/source/usr/local/emhttp/plugins/parity.check.tuning/parity.check.tuning.php
+++ b/source/usr/local/emhttp/plugins/parity.check.tuning/parity.check.tuning.php
@@ -1705,14 +1705,14 @@ function isActivePeriod() {
 		$resumeTime = ($parityTuningCfg['parityTuningResumeHour'] * 60) + $parityTuningCfg['parityTuningResumeMinute'];
 		$pauseTime  = ($parityTuningCfg['parityTuningPauseHour'] * 60) + $parityTuningCfg['parityTuningPauseMinute'];
 		$currentTime = (date("H") * 60) + date("i");
-		parityTuningLoggerTesting(".. PauseTIme=$pauseTime, Resumetime=$resumeTime, currentTime=$currentTime");
+		parityTuningLoggerTesting(".. pauseTime=$pauseTime, resumeTime=$resumeTime, currentTime=$currentTime");
 		if ($pauseTime > $resumeTime) {         // We need to allow for times spanning midnight!
 			$inPeriod = (($currentTime > $resumeTime) && ($currentTime < $pauseTime)) ? 1 : 0;
 		} else {
 			$inPeriod = (($currentTime > $resumeTime) || ($currentTime < $pauseTime)) ? 1 : 0;
 		}
 	}
-	parityTuningLoggerTesting('isAcivePeriod()='.$inPeriod);
+	parityTuningLoggerTesting('isActivePeriod()='.$inPeriod);
 	return $inPeriod;
 }
 


### PR DESCRIPTION
I have had issues with pause/resuming due to temperature, and [another user had the same issue with pause/resume from mover action](https://forums.unraid.net/topic/78394-plugin-parity-check-tuning/?do=findComment&comment=1277833).

It seems like Line 1710 needs to have the results inverted. In the above example, it resumes at midnight and should run until 11 am, and so any time between resumeTime and pauseTime should have inPeriod be true. Currently, inPeriod is never true, as it checks if currentTime < 0 (resumeTime) and currentTime > pauseTime (660).

For the second case on 1712 where we span midnight, e.g. resumeTime an hour earlier to 11pm (1380), it would seem that it is inPeriod if currentTime > resumeTime (1380) OR currentTime < pauseTime (660).