### PR TITLE
Fixed int cast in checking HeatTooLong logic

### DIFF
--- a/source/usr/local/emhttp/plugins/parity.check.tuning/parity.check.tuning.php
+++ b/source/usr/local/emhttp/plugins/parity.check.tuning/parity.check.tuning.php
@@ -456,9 +456,9 @@ switch (strtolower($command)) {
 						// Generate notification if Pause seemes to be excessive
 						// (this may be due to resume threshold being too high)
 						$waitMinutes = (int)((time() - filemtime(PARITY_TUNING_HOT_FILE)) / 60);
-						$toLongMinutes = $parityTuningCfg['parityTuningHeatTooLong'];
-						if (($waitMinutes > $toLongMinutes)
-						&&  ($waitMinutes <= ($toLongMinutes + $parityTuningCfg['parityTuningMonitorHeat'])))
+						$tooLongMinutes = $parityTuningCfg['parityTuningHeatTooLong'];
+						if (($waitMinutes > $tooLongMinutes)
+						&&  ($waitMinutes <= ($tooLongMinutes + $parityTuningCfg['parityTuningMonitorHeat'])))
 						{
 							sendTempNotification(opWithErrorCount(_('Waiting')), sprintf(_('Drives been above resume temperature threshold for %s minutes'),$waitMinutes));
 						}

--- a/source/usr/local/emhttp/plugins/parity.check.tuning/parity.check.tuning.php
+++ b/source/usr/local/emhttp/plugins/parity.check.tuning/parity.check.tuning.php
@@ -455,7 +455,7 @@ switch (strtolower($command)) {
 						parityTuningLoggerDebug (_('Array operation paused but drives not cooled enough to resume'));
 						// Generate notification if Pause seemes to be excessive
 						// (this may be due to resume threshold being too high)
-						$waitMinutes = int((time() - filemtime(PARITY_TUNING_HOT_FILE)) / 60);
+						$waitMinutes = (int)((time() - filemtime(PARITY_TUNING_HOT_FILE)) / 60);
 						$toLongMinutes = $parityTuningCfg['parityTuningHeatTooLong'];
 						if (($waitMinutes > $toLongMinutes)
 						&&  ($waitMinutes <= ($toLongMinutes + $parityTuningCfg['parityTuningMonitorHeat'])))


### PR DESCRIPTION
Unhandled exception occurs when checking if drives stay warm too long without cooling down, regardless of whether temperature notifications are enabled.

without fix in syslog:

> Jul  7 13:36:32 t1001  crond[1662]: exit status 255 from user root /usr/local/emhttp/plugins/parity.check.tuning/parity.check.tuning.php "monitor" &>/dev/null
> Jul  7 13:42:32 t1001  crond[1662]: exit status 255 from user root /usr/local/emhttp/plugins/parity.check.tuning/parity.check.tuning.php "monitor" &>/dev/null
> Jul  7 13:48:31 t1001  crond[1662]: exit status 255 from user root /usr/local/emhttp/plugins/parity.check.tuning/parity.check.tuning.php "monitor" &>/dev/null

When run manually:

> /# /usr/local/emhttp/plugins/parity.check.tuning/parity.check.tuning.php "monitor"
> 
> Warning: array_merge(): Expected parameter 1 to be an array, null given in /usr/local/emhttp/plugins/dynamix/include/CustomMerge.php on line 16
> 
> Warning: Use of undefined constant temp - assumed 'temp' (this will throw an Error in a future version of PHP) in /usr/local/emhttp/plugins/parity.check.tuning/parity.check.tuning.php on line 367
> 
> Fatal error: Uncaught Error: Call to undefined function int() in /usr/local/emhttp/plugins/parity.check.tuning/parity.check.tuning.php:458
> Stack trace:
> #0 {main}
>   thrown in /usr/local/emhttp/plugins/parity.check.tuning/parity.check.tuning.php on line 458